### PR TITLE
Hide codeEditor to prevent flash

### DIFF
--- a/views/bonfire/show.jade
+++ b/views/bonfire/show.jade
@@ -96,7 +96,7 @@ block content
             #mainEditorPanel
                 form.code
                     .form-group.codeMirrorView
-                        textarea#codeEditor(autofocus=true)
+                        textarea#codeEditor(autofocus=true, style='display: none;')
                 script(src='/js/lib/bonfire/bonfireFramework_v0.1.2.js')
 
 


### PR DESCRIPTION
Hide #codeEditor textarea so it won't flash when code mirror hides it.