### PR TITLE
App "listens" before 'MongoStore' is ready fix

### DIFF
--- a/app.js
+++ b/app.js
@@ -102,6 +102,17 @@ app.use(session({
     store: new MongoStore({
         url: secrets.db,
         'auto_reconnect': true
+    }, function(ms) {
+        /**
+         * Start Express server.
+         */
+        app.listen(app.get('port'), function () {
+            console.log(
+                'FreeCodeCamp server listening on port %d in %s mode',
+                app.get('port'),
+                app.get('env')
+            );
+        });
     })
 }));
 app.use(passport.initialize());
@@ -530,16 +541,5 @@ app.get(
  * 500 Error Handler.
  */
 app.use(errorHandler());
-
-/**
- * Start Express server.
- */
-app.listen(app.get('port'), function () {
-    console.log(
-        'FreeCodeCamp server listening on port %d in %s mode',
-        app.get('port'),
-        app.get('env')
-    );
-});
 
 module.exports = app;


### PR DESCRIPTION
When running the gulp command, the browser launches and I get an error:

> 500 Error: Error getting collection: sessions
> at \freecodecamp\node_modules\connect-mongo\lib\connect-mongo.js:160:19

Refreshing "fixes" the problem. If gulp auto reloads the project it's also fine. If I rerun the "gulp" command the error happens again.

What it looks like is happening is the browser is being launched before the following is actually ready:
```javascript
app.use(session({
    resave: true,
    saveUninitialized: true,
    secret: secrets.sessionSecret,
    store: new MongoStore({
        url: secrets.db,
        'auto_reconnect': true
    })
}));
```
MongoStore has a callback and If I move the following code into it, the problem is fixed:
```javascript
/**
 * Start Express server.
 */
app.listen(app.get('port'), function () {
    console.log(
        'FreeCodeCamp server listening on port %d in %s mode',
        app.get('port'),
        app.get('env')
    );
});
```